### PR TITLE
replaced click event with touchend for faster button response on mobile

### DIFF
--- a/public/js/view/game-view.js
+++ b/public/js/view/game-view.js
@@ -191,10 +191,10 @@ export default class GameView {
         DomHelper.getChangeNameButton().addEventListener('click', this._handleChangeNameButtonClick.bind(this));
         window.addEventListener('keydown', this._handleKeyDown.bind(this), true);
 
-        DomHelper.getUpButton().addEventListener('click', this.emitUpClicked.bind(this));
-        DomHelper.getDownButton().addEventListener('click', this.emitDownClicked.bind(this));
-        DomHelper.getLeftButton().addEventListener('click', this.emitLeftClicked.bind(this));
-        DomHelper.getRightButton().addEventListener('click', this.emitRightClicked.bind(this));
+        DomHelper.getUpButton().addEventListener('touchend', this.emitUpClicked.bind(this));
+        DomHelper.getDownButton().addEventListener('touchend', this.emitDownClicked.bind(this));
+        DomHelper.getLeftButton().addEventListener('touchend', this.emitLeftClicked.bind(this));
+        DomHelper.getRightButton().addEventListener('touchend', this.emitRightClicked.bind(this));
     }
 
     emitUpClicked() {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Replaced the click event with touchend event for snake navigation butto clicks, to avoid delay between button click and snake changing direction .
## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#21 
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
There was a slight delay between when the user clicks a navigation button (f.ex. up) and when the snake responds to this. The hypothesis is that this is due to a standard delay when using onclick event in mobile browser, see https://www.sitepoint.com/5-ways-prevent-300ms-click-delay-mobile-devices/.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

