### PR TITLE
Feature/change persist username

### DIFF
--- a/public/js/view/dom-helper.js
+++ b/public/js/view/dom-helper.js
@@ -261,12 +261,9 @@ export default class DomHelper {
     }
 
     static setPlayerNameInputElementReadOnly(readOnly) {
-        // Commenting this out for ability to enter new name:
-        /* 
-        if (this.getPlayerNameInputElement()) {
+        /*if (this.getPlayerNameInputElement()) {
             this.getPlayerNameInputElement().readOnly = readOnly;
-        }
-        */
+        }*/
     }
 
     static setPlayerNameElementValue(value) {

--- a/public/js/view/dom-helper.js
+++ b/public/js/view/dom-helper.js
@@ -261,9 +261,12 @@ export default class DomHelper {
     }
 
     static setPlayerNameInputElementReadOnly(readOnly) {
+        // Commenting this out for ability to enter new name:
+        /* 
         if (this.getPlayerNameInputElement()) {
             this.getPlayerNameInputElement().readOnly = readOnly;
         }
+        */
     }
 
     static setPlayerNameElementValue(value) {

--- a/public/js/view/game-view.js
+++ b/public/js/view/game-view.js
@@ -233,8 +233,6 @@ export default class GameView {
         /* global firebase */
         const db = firebase.database();
 
-        console.log('Trying to update player name...')
-
         if (newPlayerName && newPlayerName.trim().length > 0 && newPlayerName.length <= ClientConfig.MAX_NAME_LENGTH) {
             fetch(`/users/${newPlayerName}`).then(res => res.json()).then((data) => {
                 if (data.available) {

--- a/public/js/view/game-view.js
+++ b/public/js/view/game-view.js
@@ -241,27 +241,16 @@ export default class GameView {
                     console.log('safe to change name');
                     db.ref(`snake-scores/${oldPlayerName}`).once('value').then( snapshot => {
                         let oldData = snapshot.val();
-                        //console.log('old data', oldPlayerName, oldData);
-                        // Create new user with old data
+ 
                         db.ref(`snake-scores/${newPlayerName}`).set(oldData);
-                        //db.ref(`snake-scores/${newPlayerName}`).once('value').then( snap => {
-                        //    console.log('new data', newPlayerName, snap.val());
-                        //    console.log('updated db')
-                        //})
 
                         // Clean up old user
-                        //db.ref(`snake-scores/${oldPlayerName}`).delete();
-
-                        // Boilerplate:
-                        this.playerNameUpdatedCallback(newPlayerName);
-                        DomHelper.getPlayerNameInputElement().style.display = 'none';
-                        DomHelper.movePlayerNameToTop();
-                        this.joinGameCallback();
-                        this.isChangingName = false;
-                        DomHelper.hideInvalidPlayerNameLabel();
-                        DomHelper.hideTakenPlayerNameLabel();
-                        console.log('fired events and updated localstorage')
-                        console.log('Name changed successfully, continuing...')
+                        db.ref(`snake-scores`).child(`${oldPlayerName}`).remove();
+                        
+                        // Update and continue game
+                        this.updatePlayerName(newPlayerName);  
+                        this._saveNewPlayerName();
+                        this._createPlayer(newPlayerName);
                     });
                 } else {
                     console.log('Username '+ newPlayerName + ' already taken')
@@ -282,18 +271,16 @@ export default class GameView {
         let playerWantsToChangeName = (storedName !== playerName);
 
         if (playerWantsToChangeName) {
-            this._updatePlayerName(storedName, playerName)
-            console.log('*** RETURNING ***')
+            this._updatePlayerName(storedName, playerName);
             return;
         }
 
         if (storedName) {
-            console.log('creating player in stored name')
             this._createPlayer(storedName);
             return;
         }
 
-        console.log('getting past storedName check')
+        // Haven't played before, check name and proceed
         if (playerName && playerName.trim().length > 0 && playerName.length <= ClientConfig.MAX_NAME_LENGTH) {
             fetch(`/users/${playerName}`).then(res => res.json()).then((data) => {
                 if (data.available) {

--- a/public/js/view/game-view.js
+++ b/public/js/view/game-view.js
@@ -126,6 +126,9 @@ export default class GameView {
     _handleQuitButtonClick() {
         this.spectateGameCallback();
         DomHelper.hideControlButtons();
+        DomHelper.setPlayerNameInputElementReadOnly(false);
+        DomHelper.getPlayerNameInputElement().style.display = 'block';
+        DomHelper.getPlayerNameElement().style.display = 'none';
     }
 
     _handleKeyDown(e) {

--- a/public/js/view/game-view.js
+++ b/public/js/view/game-view.js
@@ -229,15 +229,45 @@ export default class GameView {
         });
     }
 
+    _updatePlayerName(oldPlayerName, newPlayerName) {
+        if (newPlayerName && newPlayerName.trim().length > 0 && newPlayerName.length <= ClientConfig.MAX_NAME_LENGTH) {
+            fetch(`/users/${newPlayerName}`).then(res => res.json()).then((data) => {
+                if (data.available) {
+                    // TODO LH: This means it's safe to change name
+                    // Set new key for oldPlayerName to newPlayerName
+                        // Need to reference DB from here
+                    db.ref(`snake-scores/${oldPlayerName}`).once('value').then( snapshot => {
+                        var oldData = snapshot.val();
+                        // Create new user with old data
+                        db.ref(`snake-scores/${newPlayerName}`).set(oldData);
+                        // Clean up old user
+                        db.ref(`snake-scores/${oldPlayerName}`).delete();
+                    })
+                } else {
+                    DomHelper.showTakenPlayerNameLabel();
+                }
+            });
+        } else {
+            DomHelper.showInvalidPlayerNameLabel();
+        }
+    }
+
     _register() {
+        console.log('register called')
+        
         const storedName = localStorage.getItem(ClientConfig.LOCAL_STORAGE.PLAYER_NAME);
+        const playerName = DomHelper.getPlayerNameInputElement().value;
+        let playerWantsToChangeName = (storedName !== playerName);
 
         if (storedName) {
+            if (playerDoesNotWantToChangeName){
+                this._updatePlayerName(storedName, playerName);
+                // Re-store name in LocalStorage?
+                return;
+            }
             this._createPlayer(storedName);
             return;
         }
-
-        const playerName = DomHelper.getPlayerNameInputElement().value;
 
 
         if (playerName && playerName.trim().length > 0 && playerName.length <= ClientConfig.MAX_NAME_LENGTH) {

--- a/public/js/view/game-view.js
+++ b/public/js/view/game-view.js
@@ -238,34 +238,26 @@ export default class GameView {
         if (newPlayerName && newPlayerName.trim().length > 0 && newPlayerName.length <= ClientConfig.MAX_NAME_LENGTH) {
             fetch(`/users/${newPlayerName}`).then(res => res.json()).then((data) => {
                 if (data.available) {
-                    console.log('safe to change name');
                     db.ref(`snake-scores/${oldPlayerName}`).once('value').then( snapshot => {
                         let oldData = snapshot.val();
- 
                         db.ref(`snake-scores/${newPlayerName}`).set(oldData);
-
                         // Clean up old user
                         db.ref(`snake-scores`).child(`${oldPlayerName}`).remove();
-                        
                         // Update and continue game
                         this.updatePlayerName(newPlayerName);  
                         this._saveNewPlayerName();
                         this._createPlayer(newPlayerName);
                     });
                 } else {
-                    console.log('Username '+ newPlayerName + ' already taken')
                     DomHelper.showTakenPlayerNameLabel();
                 }
             });
         } else {
-            console.log('does not meet reqs')
             DomHelper.showInvalidPlayerNameLabel();
         }
     }
 
     _register() {
-        console.log('register called')
-        
         const storedName = localStorage.getItem(ClientConfig.LOCAL_STORAGE.PLAYER_NAME);
         const playerName = DomHelper.getPlayerNameInputElement().value;
         let playerWantsToChangeName = (storedName !== playerName);


### PR DESCRIPTION
Please test and review. I've tested to best of my abilities, and seems to be working.

Features:
- Change name on re-visit or refresh
- Change name on quit button
- In name change mode (welcome back via re-visit, refresh or quit):
---- Error when username exists, username stays the same
---- Error when username exists, enter original username again, enters as original username with same score
--- Error when username exists, enter a new username that is not taken, enters as new name with same score. Score is persisted in DB, moved to new username, entry with old username is deleted